### PR TITLE
Adding group selection

### DIFF
--- a/backend/index.php
+++ b/backend/index.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 header('Content-Type: application/json');
 header('Access-Control-Allow-Origin: *');
 
-$table = 'WU22';
-$dbName = 'MagnusVV_Issue';
+$table = 'WU23'; 
+$dbName = 'wu23';
 $db = new PDO('sqlite:' . $dbName . '.sqlite3');
 
 $stmt = $db->query("SELECT * FROM '$table'");
@@ -14,4 +14,4 @@ $stmt->execute();
 $result = $stmt->fetchAll(PDO::FETCH_ASSOC);
 echo json_encode($result);
 
-var_dump($db);
+/* var_dump($db); */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,8 +9,21 @@
 </head>
 <body>
     <div class="container">
-    <header><button id="pairProgrammerButton">Set pairprogrammers</button>
-        <button id="toggle-button">Toggle dark mode</button></header>
+    <header>
+        <button id="pairProgrammerButton">Set pairprogrammers</button>
+        <button id="toggle-button">Toggle dark mode</button>
+        <div class="button-container">
+            <button id="createGroupsButton" class="group-button">Create groups</button>
+            <div class="dropdown">
+                <button id="dropdownButton" class="dropdown-button">▼</button>
+                <div id="dropdownMenu" class="dropdown-menu">                    
+                    <a href="#" data-size="3">3</a>
+                    <a href="#" data-size="4">4</a>
+                    <a href="#" data-size="5">5</a>
+                </div>
+            </div>
+        </div>
+    </header>
     <section id="selection">
         <div id="present"></div>
         <div id="away"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,7 @@
                     <a href="#" data-size="3">3</a>
                     <a href="#" data-size="4">4</a>
                     <a href="#" data-size="5">5</a>
+                    <a href="#" data-size="6">6</a>
                 </div>
             </div>
         </div>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,7 +1,69 @@
+//old constants and variables
 let present = document.getElementById("present");
 let away = document.getElementById("away");
 let result = document.getElementById("result");
 const pairProgrammerButton = document.getElementById("pairProgrammerButton");
+
+//New constants and variables
+const createGroupsButton = document.getElementById('createGroupsButton');
+const dropdownButton = document.getElementById('dropdownButton');
+const dropdownMenu = document.getElementById('dropdownMenu');
+const dropdown = dropdownButton.parentElement;
+let selectedGroupSize = 3; //the default group size is 3 since the size of 2 is already handled by the pair button
+
+//eventlisteners and clickhandlers for group button and dropdown button
+dropdownButton.addEventListener('click', () => {
+    dropdown.classList.toggle('show');
+});
+
+dropdownMenu.addEventListener('click', (event) => {
+    if (event.target.tagName === 'A') {
+        event.preventDefault();
+        selectedGroupSize = parseInt(event.target.getAttribute('data-size'), 10);
+        dropdown.classList.remove('show');
+    }
+});
+
+document.addEventListener('click', (event) => {
+    if (!dropdown.contains(event.target)) {
+        dropdown.classList.remove('show');
+    }
+});
+
+createGroupsButton.addEventListener('click', () => {
+    let studentsArray = Array.from(present.childNodes);
+    let groups = createGroups(studentsArray, selectedGroupSize);
+
+    //groups the students in even groups, if there are "leftovers", theese students gets put in an already full group instead of having a half a group
+    result.innerHTML = '';
+    groups.forEach(group => {
+        let groupDiv = document.createElement('div');
+        group.forEach(student => {
+            groupDiv.appendChild(student);
+        });
+        result.appendChild(groupDiv);
+    });
+});
+
+//create groups based on user preferd group size
+function createGroups(students, groupSize) {
+    const numberOfGroups = Math.floor(students.length / groupSize);
+    const leftover = students.length % groupSize;
+
+    const groups = [];
+    let startIndex = 0;
+
+    
+    for (let i = 0; i < numberOfGroups; i++) {
+        let extraMember = i < leftover ? 1 : 0; //sprinkle the leftover students in groups
+        groups.push(students.slice(startIndex, startIndex + groupSize + extraMember));
+        startIndex += groupSize + extraMember;
+    }
+
+    return groups;
+}
+
+  
 
 //events
 pairProgrammerButton.addEventListener("click", shuffleStudents);

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -47,20 +47,19 @@ createGroupsButton.addEventListener('click', () => {
 
 //create groups based on user preferd group size
 function createGroups(students, groupSize) {
-    const numberOfGroups = Math.floor(students.length / groupSize);
-    const leftover = students.length % groupSize;
+  //calculate the number of groups needed
+  const numberOfGroups = Math.ceil(students.length / groupSize);
+  const groups = Array.from({ length: numberOfGroups }, () => []);
 
-    const groups = [];
-    let startIndex = 0;
+  let currentGroupIndex = 0;
 
-    
-    for (let i = 0; i < numberOfGroups; i++) {
-        let extraMember = i < leftover ? 1 : 0; //sprinkle the leftover students in groups
-        groups.push(students.slice(startIndex, startIndex + groupSize + extraMember));
-        startIndex += groupSize + extraMember;
-    }
+  //loop through every students and assign them to groups
+  for (let i = 0; i < students.length; i++) {
+      groups[currentGroupIndex].push(students[i]);
+      currentGroupIndex = (currentGroupIndex + 1) % numberOfGroups;
+  }
 
-    return groups;
+  return groups;
 }
 
   

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -97,3 +97,65 @@ button {
 #selection .drag-over {
     border: dashed 3px red;
 }
+
+
+
+
+/*dropdown changes*/
+
+/* Container styling */
+.button-container {
+    display: inline-flex;       
+    position: relative;
+    background-color: #77e;
+    border-radius: .4rem;
+}
+
+.dropdown {
+    position: relative;   
+}
+
+/* Styling the dropdown button */
+.dropdown-button.group-button {
+    background-color: #77e;
+    color: whitesmoke;
+    font-size: 1.25rem;
+    border: none;
+    padding: .5rem 1rem;
+    cursor: pointer;
+    border-radius: 0;
+}
+
+.dropdown-button:active{
+    transform: scale(1.2);
+}
+
+/* Dropdown menu styling */
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background-color: #77e;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    z-index: 999;
+    width: 100%;
+}
+
+.dropdown-menu a {
+    display: block;
+    padding: 10px 15px;
+    text-decoration: none;
+    color: whitesmoke;
+    font-size: 16px;
+}
+
+.dropdown-menu a:hover {
+    background-color: whitesmoke;
+    color: #77e;
+}
+
+.dropdown.show .dropdown-menu {
+    display: block; 
+}


### PR DESCRIPTION
_I could not find any PR template as stated in the contribute.md?_ 

# Adding group selection

### Summary
- This PR is adding a button next to the 'pair programmers' button. This button lets the user select a group size and then group the available students into groups. It can also handle the situation of odd numbers and if there are "leftover" students, instead of creating a half full group it sprinkles the "leftovers" into the other groups. 

### Related Issues
- This PR solves the issue #5 

### Changes
- I have changed the html file, where I added the html elements I needed to create the buttons. 
- I have added some css to style the buttons and the dropdownmenu.
- I have added JS to index.js to create nodes and create eventhandlers aswell as adding the acutal logic to group the students. 

### Testing
- I have tested the application by running it on localhost. During my tests I have encounterd 0 issues and it workes as intended. 

## Important to note that none of theese changes are in any way conflicting or impact the 'old' code. 
- The original 'pair programmers' functionality are not touched at all. In fact I've set the default group size to 3 and thats the minimum size becouse of this fact. So the group button are only to be used if the user wants to create groups of 3 or more. Otherwise the user should still be using the original 'pair programeers' button. **IF** the community so wishes it would be a simple task to adjust the code to remove the original button and add a group size of 2 to the new group button if you want to remove the old button entirely.
